### PR TITLE
Improve Hn tags on title of customtext module

### DIFF
--- a/ps_customtext.php
+++ b/ps_customtext.php
@@ -262,7 +262,7 @@ class Ps_Customtext extends Module implements WidgetInterface
         $return = true;
         $tab_texts = array(
             array(
-                'text' => '<h3>Custom Text Block</h3>
+                'text' => '<h2>Custom Text Block</h2>
 <p><strong class="dark">Lorem ipsum dolor sit amet conse ctetu</strong></p>
 <p>Sit amet conse ctetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.</p>'
             ),


### PR DESCRIPTION
Improve SEO Hn tags on Classic Theme for the title of Custom text module.

Link to this PR: https://github.com/PrestaShop/PrestaShop/pull/8741 and https://github.com/PrestaShop/ps_imageslider/pull/21
Ticket link: http://forge.prestashop.com/browse/FF-158

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_customtext/11)
<!-- Reviewable:end -->
