### PR TITLE
Uninstall 1.6 equivalent module before installing ps_customtext

### DIFF
--- a/classes/CustomText.php
+++ b/classes/CustomText.php
@@ -53,7 +53,7 @@ class CustomText extends ObjectModel
 	 * @param int $shopId
 	 * @return bool|int
 	 */
-	static function getCustomTextIdByShop($shopId) 
+	public static function getCustomTextIdByShop($shopId)
 	{
 		$sql = 'SELECT i.`id_info` FROM `' . _DB_PREFIX_ . 'info` i
 		LEFT JOIN `' . _DB_PREFIX_ . 'info_shop` ish ON ish.`id_info` = i.`id_info`

--- a/classes/MigrateData.php
+++ b/classes/MigrateData.php
@@ -58,10 +58,9 @@ class MigrateData
     /**
      * Import the old CustomText data in the new structure
      *
-     * @param $text
      * @return bool
      */
-    function insertData()
+    public function insertData()
     {
         if (empty($this->loadedData)) {
             return true;

--- a/classes/MigrateData.php
+++ b/classes/MigrateData.php
@@ -1,0 +1,88 @@
+<?php
+/*
+ * 2007-2018 PrestaShop
+ * 
+ * NOTICE OF LICENSE
+ * 
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ * 
+ * DISCLAIMER
+ * 
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ * 
+ *  @author PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2018 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * Database may change between two version of the module, or between the 1.6 and 1.7 modules.
+ * This class allow the data to be kept during upgrades and migrations.
+ */
+class MigrateData
+{
+    private $loadedData = array();
+
+    /**
+     * This methods retrieves data from older database models
+     * - ps_customtext < v3.0.0
+     * - blockcmsinfo (1.6 equivalent module)
+     *
+     * @return type
+     */
+    public function retrieveOldData()
+    {
+        $this->loadedData = array();
+        $texts = Db::getInstance()->executeS('SELECT i.`id_shop`, il.`id_lang`, il.`text` FROM `' . _DB_PREFIX_ . 'info` i
+            INNER JOIN `' . _DB_PREFIX_ . 'info_lang` il ON il.`id_info` = i.`id_info`'
+        );
+
+        if (is_array($texts) && !empty($texts)) {
+            foreach ($texts as $text) {
+                $this->loadedData[(int)$text['id_shop']][(int)$text['id_lang']] = $text['text'];
+            }
+        }
+
+        return $this->loadedData;
+    }
+
+    /**
+     * Inserting the old CustomText data
+     *
+     * @param $text
+     * @return bool
+     */
+    function insertData()
+    {
+        if (empty($this->loadedData)) {
+            return true;
+        }
+        
+        $return = true;
+        $shopsIds = Shop::getShops(true, null, true);
+        $customTexts = array_intersect_key($this->loadedData, $shopsIds);
+
+        $info = new CustomText();
+        $info->text = reset($customTexts);
+        $return &= $info->add();
+
+        if (sizeof($customTexts) > 1) {
+            foreach ($customTexts as $key => $text) {
+                Shop::setContext(Shop::CONTEXT_SHOP, (int) $key);
+                $info->text = $text;
+                $return &= $info->save();
+            }
+        }
+
+        return $return;
+    }
+}

--- a/classes/MigrateData.php
+++ b/classes/MigrateData.php
@@ -37,7 +37,7 @@ class MigrateData
      * - ps_customtext < v3.0.0
      * - blockcmsinfo (1.6 equivalent module)
      *
-     * @return type
+     * @return array
      */
     public function retrieveOldData()
     {
@@ -56,7 +56,7 @@ class MigrateData
     }
 
     /**
-     * Inserting the old CustomText data
+     * Import the old CustomText data in the new structure
      *
      * @param $text
      * @return bool

--- a/ps_customtext.php
+++ b/ps_customtext.php
@@ -59,6 +59,12 @@ class Ps_Customtext extends Module implements WidgetInterface
 
     public function install()
     {
+        // Remove 1.6 equivalent module to avoid DB issues
+        $module16 = 'blockcmsinfo';
+        if (Module::isInstalled($module16)) {
+            Module::getInstanceByName($module16)->uninstall();
+        }
+
         return parent::install()
             && $this->installDB()
             && $this->registerHook('displayHome')

--- a/ps_customtext.php
+++ b/ps_customtext.php
@@ -67,7 +67,8 @@ class Ps_Customtext extends Module implements WidgetInterface
             return $this->installFrom16Version();
         }
 
-        return $this->runInstallSteps();
+        return $this->runInstallSteps()
+            && $this->installFixtures();
     }
 
     public function runInstallSteps()
@@ -75,7 +76,6 @@ class Ps_Customtext extends Module implements WidgetInterface
         return parent::install()
             && $this->installDB()
             && $this->registerHook('displayHome')
-            && $this->installFixtures()
             && $this->registerHook('actionShopDataDuplication');
     }
 

--- a/ps_customtext.php
+++ b/ps_customtext.php
@@ -59,13 +59,8 @@ class Ps_Customtext extends Module implements WidgetInterface
 
     public function install()
     {
-        // Remove 1.6 equivalent module to avoid DB issues
-        $module16 = 'blockcmsinfo';
-        if (Module::isInstalled($module16)) {
-            Module::getInstanceByName($module16)->uninstall();
-        }
-
-        return parent::install()
+        return $this->cleanPreviousModule()
+            && parent::install()
             && $this->installDB()
             && $this->registerHook('displayHome')
             && $this->installFixtures()
@@ -75,6 +70,21 @@ class Ps_Customtext extends Module implements WidgetInterface
     public function uninstall()
     {
         return parent::uninstall() && $this->uninstallDB();
+    }
+
+    public function cleanPreviousModule()
+    {
+      // Remove 1.6 equivalent module to avoid DB issues
+      $module16 = 'blockcmsinfo';
+      if (!Module::isInstalled($module16)) {
+        return true;
+      }
+
+      $oldModule = Module::getInstanceByName($module16);
+      if ($oldModule) {
+          return $oldModule->uninstall();
+      }
+      return $this->uninstallDB(true);
     }
 
     public function installDB()
@@ -261,7 +271,7 @@ class Ps_Customtext extends Module implements WidgetInterface
     }
     public function getWidgetVariables($hookName = null, array $configuration = [])
     {
-        $sql = 'SELECT * FROM `'._DB_PREFIX_.'info_lang` 
+        $sql = 'SELECT * FROM `'._DB_PREFIX_.'info_lang`
             WHERE `id_lang` = '.(int)$this->context->language->id.' AND  `id_shop` = '.(int)$this->context->shop->id;
 
         return array(

--- a/ps_customtext.php
+++ b/ps_customtext.php
@@ -35,6 +35,7 @@ require_once _PS_MODULE_DIR_.'ps_customtext/classes/CustomText.php';
 
 class Ps_Customtext extends Module implements WidgetInterface
 {
+    // Equivalent module on PrestaShop 1.6, sharing the same data
     const MODULE_16 = 'blockcmsinfo';
 
     private $templateFile;
@@ -80,7 +81,7 @@ class Ps_Customtext extends Module implements WidgetInterface
 
     public function installFrom16Version()
     {
-        include_once(_PS_MODULE_DIR_.$this->name.'/classes/MigrateData.php');
+        require_once _PS_MODULE_DIR_.$this->name.'/classes/MigrateData.php';
         $migration = new MigrateData();
         $migration->retrieveOldData();
 

--- a/upgrade/install-3.0.0.php
+++ b/upgrade/install-3.0.0.php
@@ -36,7 +36,7 @@ if (!defined('_PS_VERSION_')) {
  */
 function upgrade_module_3_0_0($module)
 {
-    include_once(_PS_MODULE_DIR_.$module->name.'/classes/MigrateData.php');
+    require_once _PS_MODULE_DIR_.$module->name.'/classes/MigrateData.php';
     $migration = new MigrateData();
 
     $return = true;

--- a/upgrade/install-3.0.0.php
+++ b/upgrade/install-3.0.0.php
@@ -42,30 +42,12 @@ function upgrade_module_3_0_0($module)
     $return = true;
 
     $migration->retrieveOldData();
-
-    /** Delete the column id_shop from info table */
-    $return &= Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . 'info` DROP `id_shop`');
-
-    /** Add the column id_shop and define as primary key in the table info_lang */
-    $return &= Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . 'info_lang` ADD `id_shop` INT(10) UNSIGNED NOT NULL');
-    $return &= Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . 'info_lang` DROP PRIMARY KEY, ADD PRIMARY KEY(`id_info`, `id_lang`, `id_shop`)');
-
-    /** Create the info_shop table */
-    $return &= Db::getInstance()->execute('
-                CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'info_shop` (
-                `id_info` INT(10) UNSIGNED NOT NULL,
-                `id_shop` INT(10) UNSIGNED NOT NULL,
-                PRIMARY KEY (`id_info`, `id_shop`)
-                ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8 ;'
-    );
+    $return &= $module->uninstallDB();
 
     /** Register the hook responsible for adding custom text when adding a new store */
     $return &= $module->registerHook('actionShopDataDuplication');
 
-    /** Truncate all DB table */
-    $return &= Db::getInstance()->execute('TRUNCATE `' . _DB_PREFIX_ . 'info`');
-    $return &= Db::getInstance()->execute('TRUNCATE `' . _DB_PREFIX_ . 'info_shop`');
-    $return &= Db::getInstance()->execute('TRUNCATE `' . _DB_PREFIX_ . 'info_lang`');
+    $return &= $module->installDB();
 
     /** Reset DB data */
     $return &= $migration->insertData();


### PR DESCRIPTION
`blockcmsinfo` (PrestaShop 1.6) and `ps_customtext` (PrestaShop 1.7) use the same tables in the database, but with different structures!

This leads to conflicts while installing this module, and breaking the upgrade process between 1.6 & 1.7. (Found by @marionf)

## Fixed issue

![image](https://user-images.githubusercontent.com/6768917/42391034-da739804-8145-11e8-9bba-250b8c551034.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_customtext/13)
<!-- Reviewable:end -->
