### PR TITLE
Implement call to hook filterHtmlContent on modules HTML

### DIFF
--- a/ps_customtext.php
+++ b/ps_customtext.php
@@ -27,10 +27,10 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
+use PrestaShop\PrestaShop\Adapter\ObjectPresenter;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 
 require_once _PS_MODULE_DIR_ . 'ps_customtext/classes/CustomText.php';
-
 class Ps_Customtext extends Module implements WidgetInterface
 {
     // Equivalent module on PrestaShop 1.6, sharing the same data
@@ -279,12 +279,14 @@ class Ps_Customtext extends Module implements WidgetInterface
 
     public function getWidgetVariables($hookName = null, array $configuration = [])
     {
-        $sql = 'SELECT * FROM `' . _DB_PREFIX_ . 'info_lang`
-            WHERE `id_lang` = ' . (int) $this->context->language->id . ' AND  `id_shop` = ' . (int) $this->context->shop->id;
+        $customText = new CustomText(1, (int) $this->context->language->id, (int) $this->context->shop->id);
+        $objectPresenter = new ObjectPresenter();
+        $data = $objectPresenter->present($customText);
+        $data['id_lang'] = $this->context->language->id;
+        $data['id_shop'] = $this->context->shop->id;
+        unset($data['id']);
 
-        return [
-            'cms_infos' => Db::getInstance()->getRow($sql),
-        ];
+        return ['cms_infos' => $data];
     }
 
     public function installFixtures()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The module ps_customtext has the ability to show HTML at desired places. Since Prestashop 1.7.1 hook filterHTMLContent is implemented allowing module developers to react to codes in HTML and inject module generated HTML in the resulting HTML.<br> This change updates ps_customtext in such way that the HTML of this module is treated as any other prestashop HTML, so that hook filterHTMLContent is called also,
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/18520
| How to test?  | HTML content of the module should display as usual. Should process module hooked to filterHTMLContent.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_customtext/53)
<!-- Reviewable:end -->
