### PR TITLE
Reset the shop context as before the submit action

### DIFF
--- a/ps_customtext.php
+++ b/ps_customtext.php
@@ -170,6 +170,9 @@ class Ps_Customtext extends Module implements WidgetInterface
 
     public function processSaveCustomText()
     {
+        $shopCurrentContext = Shop::getContext();
+        $shopCurrentId = $this->context->shop->id;
+        $shopCurrentGroupId = Shop::getContextShopGroupID();
         $shops = Tools::getValue('checkBoxShopAsso_configuration', [$this->context->shop->id]);
         $text = [];
         $languages = Language::getLanguages(false);
@@ -181,9 +184,17 @@ class Ps_Customtext extends Module implements WidgetInterface
         $saved = true;
         foreach ($shops as $shop) {
             Shop::setContext(Shop::CONTEXT_SHOP, $shop);
-            $info = new CustomText(Tools::getValue('id_info', 1));
+            $info = new CustomText((int) Tools::getValue('id_info', 1), null, $shop);
             $info->text = $text;
             $saved &= $info->save();
+        }
+
+        if ($shopCurrentContext == Shop::CONTEXT_SHOP) {
+            Shop::setContext(Shop::CONTEXT_SHOP, $shopCurrentId);
+        } elseif ($shopCurrentContext == Shop::CONTEXT_GROUP) {
+            Shop::setContext(Shop::CONTEXT_GROUP, $shopCurrentGroupId);
+        } elseif ($shopCurrentContext == Shop::CONTEXT_ALL) {
+            Shop::setContext(Shop::CONTEXT_ALL);
         }
 
         return $saved;


### PR DESCRIPTION
In multishop case, we should reset the shop context as before the submit action
Shop::setContext() in foreach loop, has side effect, it change the current shop context

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?         | bug fix / improvement / new feature / refacto / critical
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
