### PR TITLE
Show error instead of exception when the text is not valid

### DIFF
--- a/ps_customtext.php
+++ b/ps_customtext.php
@@ -207,7 +207,7 @@ class Ps_Customtext extends Module implements WidgetInterface
             $text[$lang['id_lang']] = (string) Tools::getValue('text_' . $lang['id_lang']);
 
             if (!Configuration::get('PS_ALLOW_HTML_IFRAME') && preg_match('/<iframe.*src=\"(.*)\".*><\/iframe>/isU', $text[$lang['id_lang']])) {
-                $this->context->controller->errors[] = $this->trans('To use <iframe>, enable the feature in Shop Parameters> General', [], 'Admin.Notifications.Error');
+                $this->context->controller->errors[] = $this->trans('To use <iframe>, enable the feature in Shop Parameters > General', [], 'Admin.Notifications.Error');
 
                 return false;
             }

--- a/ps_customtext.php
+++ b/ps_customtext.php
@@ -207,7 +207,7 @@ class Ps_Customtext extends Module implements WidgetInterface
             $text[$lang['id_lang']] = (string) Tools::getValue('text_' . $lang['id_lang']);
 
             if (!Configuration::get('PS_ALLOW_HTML_IFRAME') && preg_match('/<iframe.*src=\"(.*)\".*><\/iframe>/isU', $text[$lang['id_lang']])) {
-                $this->context->controller->errors[] = $this->trans('If you want to use <iframe> inside your content, enable them in Preferences -> General -> Allow iframes on HTML fields', [], 'Admin.Notifications.Error');
+                $this->context->controller->errors[] = $this->trans('To use <iframe>, enable the feature in Shop Parameters> General', [], 'Admin.Notifications.Error');
 
                 return false;
             }

--- a/ps_customtext.php
+++ b/ps_customtext.php
@@ -47,7 +47,7 @@ class Ps_Customtext extends Module implements WidgetInterface
         $this->name = 'ps_customtext';
         $this->tab = 'front_office_features';
         $this->author = 'PrestaShop';
-        $this->version = '4.2.0';
+        $this->version = '4.2.1';
         $this->need_instance = 0;
 
         $this->bootstrap = true;
@@ -205,6 +205,12 @@ class Ps_Customtext extends Module implements WidgetInterface
 
         foreach ($languages as $lang) {
             $text[$lang['id_lang']] = (string) Tools::getValue('text_' . $lang['id_lang']);
+
+            if (!Configuration::get('PS_ALLOW_HTML_IFRAME') && preg_match('/<iframe.*src=\"(.*)\".*><\/iframe>/isU', $text[$lang['id_lang']])) {
+                $this->context->controller->errors[] = $this->trans('If you want to use <iframe> inside your content, enable them in Preferences -> General -> Allow iframes on HTML fields', [], 'Admin.Notifications.Error');
+
+                return false;
+            }
         }
 
         $saved = true;
@@ -212,7 +218,12 @@ class Ps_Customtext extends Module implements WidgetInterface
             Shop::setContext(Shop::CONTEXT_SHOP, $shop);
             $info = new CustomText(Tools::getValue('id_info', 1));
             $info->text = $text;
-            $saved = $saved && $info->save();
+
+            try {
+                $saved = $saved && $info->save();
+            } catch (PrestaShopException $e) {
+                $saved = false;
+            }
         }
 
         return $saved;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | First, we properly handle exceptions. Secondly, we try to determine if merchants are trying to use `iframe` inside the content if they haven't enabled it yet
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#9707
| How to test?  | Disable "Allow iframe" in "Preferences -> General" and try to insert iframe inside the module. Before, and after this PR.
| Sponsor company | impSolutions

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_customtext/71)
<!-- Reviewable:end -->
