### PR TITLE
Display the info of the shop, no hardcoded id_info=1

### DIFF
--- a/ps_customtext.php
+++ b/ps_customtext.php
@@ -338,7 +338,7 @@ class Ps_Customtext extends Module implements WidgetInterface
      * @param string|null $hookName
      * @param array $configuration
      *
-     * @return array<string, mixed> | false
+     * @return array<string, mixed>|false
      */
     public function getWidgetVariables($hookName = null, array $configuration = [])
     {

--- a/ps_customtext.php
+++ b/ps_customtext.php
@@ -318,12 +318,18 @@ class Ps_Customtext extends Module implements WidgetInterface
      * @param string|null $hookName
      * @param array $configuration
      *
-     * @return string
+     * @return string|false
      */
     public function renderWidget($hookName = null, array $configuration = [])
     {
         if (!$this->isCached($this->templateFile, $this->getCacheId('ps_customtext'))) {
-            $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));
+            $var_array = $this->getWidgetVariables($hookName, $configuration);
+            if ($var_array === false) {
+
+                return false;
+            }
+
+            $this->smarty->assign($var_array);
         }
 
         return $this->fetch($this->templateFile, $this->getCacheId('ps_customtext'));
@@ -333,12 +339,17 @@ class Ps_Customtext extends Module implements WidgetInterface
      * @param string|null $hookName
      * @param array $configuration
      *
-     * @return array<string, mixed>
+     * @return array<string, mixed> | false
      */
     public function getWidgetVariables($hookName = null, array $configuration = [])
     {
         $id_shop = (int) $this->context->shop->id;
         $id_info = CustomText::getCustomTextIdByShop($id_shop);
+        if ($id_info === false) {
+
+            return false;
+        }
+
         $customText = new CustomText($id_info, $this->context->language->id, $id_shop);
         $objectPresenter = new ObjectPresenter();
         $data = $objectPresenter->present($customText);

--- a/ps_customtext.php
+++ b/ps_customtext.php
@@ -323,13 +323,12 @@ class Ps_Customtext extends Module implements WidgetInterface
     public function renderWidget($hookName = null, array $configuration = [])
     {
         if (!$this->isCached($this->templateFile, $this->getCacheId('ps_customtext'))) {
-            $var_array = $this->getWidgetVariables($hookName, $configuration);
-            if ($var_array === false) {
-
+            $widgetVariables = $this->getWidgetVariables($hookName, $configuration);
+            if ($widgetVariables === false) {
                 return false;
             }
 
-            $this->smarty->assign($var_array);
+            $this->smarty->assign($widgetVariables);
         }
 
         return $this->fetch($this->templateFile, $this->getCacheId('ps_customtext'));
@@ -346,7 +345,6 @@ class Ps_Customtext extends Module implements WidgetInterface
         $id_shop = (int) $this->context->shop->id;
         $id_info = CustomText::getCustomTextIdByShop($id_shop);
         if ($id_info === false) {
-
             return false;
         }
 

--- a/ps_customtext.php
+++ b/ps_customtext.php
@@ -342,17 +342,17 @@ class Ps_Customtext extends Module implements WidgetInterface
      */
     public function getWidgetVariables($hookName = null, array $configuration = [])
     {
-        $id_shop = (int) $this->context->shop->id;
-        $id_info = CustomText::getCustomTextIdByShop($id_shop);
-        if ($id_info === false) {
+        $idShop = (int) $this->context->shop->id;
+        $idInfo = CustomText::getCustomTextIdByShop($idShop);
+        if ($idInfo === false) {
             return false;
         }
 
-        $customText = new CustomText($id_info, $this->context->language->id, $id_shop);
+        $customText = new CustomText($idInfo, $this->context->language->id, $idShop);
         $objectPresenter = new ObjectPresenter();
         $data = $objectPresenter->present($customText);
         $data['id_lang'] = $this->context->language->id;
-        $data['id_shop'] = $id_shop;
+        $data['id_shop'] = $idShop;
         unset($data['id']);
 
         return ['cms_infos' => $data];

--- a/ps_customtext.php
+++ b/ps_customtext.php
@@ -337,11 +337,13 @@ class Ps_Customtext extends Module implements WidgetInterface
      */
     public function getWidgetVariables($hookName = null, array $configuration = [])
     {
-        $customText = new CustomText(1, (int) $this->context->language->id, (int) $this->context->shop->id);
+        $id_shop = (int) $this->context->shop->id;
+        $id_info = CustomText::getCustomTextIdByShop($id_shop);
+        $customText = new CustomText($id_info, $this->context->language->id, $id_shop);
         $objectPresenter = new ObjectPresenter();
         $data = $objectPresenter->present($customText);
         $data['id_lang'] = $this->context->language->id;
-        $data['id_shop'] = $this->context->shop->id;
+        $data['id_shop'] = $id_shop;
         unset($data['id']);
 
         return ['cms_infos' => $data];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If there is more than one info, we must display the info of the current shop. id_info = 1 was hardcoded.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#29062.
| How to test?  | Follow the steps to reproduce in the ticket. With this fix all the info texts will display.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/ps_customtext/72)
<!-- Reviewable:end -->
