### PR TITLE
Add missing fail-fast in CI

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -57,6 +57,7 @@ jobs:
     name: PHPStan
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         presta-versions: ['1.7.5.1', '1.7.6', '1.7.7', '1.7.8', 'latest']
     steps:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | We know that PHPstan cannot run with the tag `latest` to avoid the whole matrix to be cancelled if latest is called first and fails, we disable the `fail-fast` feature of the GitHub actions.
| Type?         | bug fix
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | @PrestaShopCorp
| How to test?  | CI remains green expect PHPStan (latest)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
